### PR TITLE
fix: `M` isn't declared.

### DIFF
--- a/lua/lsp-timeout/config.lua
+++ b/lua/lsp-timeout/config.lua
@@ -1,8 +1,9 @@
 -- Default config
 --- Configuration class
 --- @class M.Config
+local M = {}
 M.Config = { prototype = { ctx = {}, constructor = M.Config } }
-M.Config._mt = { 
+M.Config._mt = {
 	__index = function(table, key)
 		if key == "constructor" then return M.Config end
 		return table.constructor.prototype[key]


### PR DESCRIPTION
This error occur because `M` isn't declared.
![Screenshot (176)](https://github.com/hinell/lsp-timeout.nvim/assets/74944536/2a4f2d81-924c-4543-b1de-fb9e4dbcb21b)
