### PR TITLE
(fix) add missing comma to example conf

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -64,7 +64,7 @@ See DEVELOPMENT.md for more info.
 vim.g.lspTimeoutConfig = {
     stopTimeout  = 1000 * 60 * 5, -- ms, timeout before stopping all LSPs 
     startTimeout = 1000 * 10,     -- ms, timeout before restart
-    silent       = false          -- true to suppress notifications
+    silent       = false,         -- true to suppress notifications
     filetypes    = {
         ignore = {                -- filetypes to ignore; empty by default
                                   -- lsp-timeout is disabled completely


### PR DESCRIPTION
### LEGAL
- [x] I've read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and I'm fully aware of the terms
- [x] I've read the [LICENSE](../blob/main/LICENSE) and fully accept the terms and waive my rights over this contribution

### SUMMARY

I copy/pasted the example config and was greeted with a syntax error. This fixes that

### CONTEXT
- [ ] I've [DISCUSSED](../discussions) this proposal or feature earlier
