### PR TITLE
Replaces: `vim.tbl_isarray` -> `vim.tbl_islist`

### DIFF
--- a/lua/lsp-timeout/config.lua
+++ b/lua/lsp-timeout/config.lua
@@ -67,7 +67,7 @@ function M.Config.prototype:validate()
 	end
 
 	if self.filetypes ~= nil then
-		if (vim.tbl_isarray(self.filetypes) and not vim.tbl_isempty(self.filetypes))
+		if (vim.tbl_islist(self.filetypes) and not vim.tbl_isempty(self.filetypes))
 		or not self.filetypes.ignore then
 			error("lsp-timeout.config.filetypes: { ignore = { .. } } is expected, got "
 			.. vim.inspect(self.filetypes), 2)


### PR DESCRIPTION
### LEGAL
- [x] I've read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and I'm fully aware of the terms
- [x] I've read the [LICENSE](../blob/main/LICENSE) and fully accept the terms and waive my rights over this contribution

### SUMMARY

It looks like Neovim is leaning towards the [new `vim.tbl_islist` instead of the `vim.tbl_isarray`](https://github.com/neovim/neovim/pull/16440), so I suggest changing this plugin to the new function. Also, the new `tbl_islist` is already used in other places in this plugin : )





### CONTEXT

I haven't found any commit or discussion deprecating `vim.tbl_isarray` but in my Neovim 0.9.2 it does not exist anymore — `:lua vim.tbl_isarray()` ends up in:

```
E5108: Error executing lua [string ":lua"]:1: attempt to call field 'tbl_isarray' (a nil value)
stack traceback:
        [string ":lua"]:1: in main chunk
```

Also, `:help vim.tbl_isarray` gives me `E149: Sorry, no help for vim.tbl_isarray`. 

It looks like [I'm not the only one](https://vi.stackexchange.com/questions/42803/neovim-telescope-fails-to-find-tbl-isarray).

<!--
- [ ] I've [DISCUSSED](../discussions) this proposal or feature earlier
-->

I've **not** [DISCUSSED](../discussions) this proposal or feature earlier. It is a simple change and I thought it would be too much to start a thread. Also, 100% ok if you just close this PR without merging, no problem at all : )